### PR TITLE
use `#[panic_handler]` instead of `#[panic_implementation]`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,11 @@ matrix:
 
     - env: TARGET=thumbv6m-none-eabi
       rust: nightly
+      if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)
 
     - env: TARGET=thumbv7m-none-eabi
       rust: nightly
+      if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)
 
 before_install: set -e
 
@@ -18,6 +20,9 @@ install:
 
 script:
   - bash ci/script.sh
+
+after_success:
+  - bash ci/after-success.sh
 
 after_script: set +e
 
@@ -28,6 +33,7 @@ before_cache:
 
 branches:
   only:
+    - master
     - staging
     - trying
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.2.1] - 2018-09-03
+
+- Move from the `panic_implementation` attribute to the `panic_handler`
+  attribute, which will be stabilized.
+
 ## [v0.2.0] - 2018-06-04
 
 ### Changed
@@ -24,6 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Initial release
 
-[Unreleased]: https://github.com/japaric/panic-abort/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/japaric/panic-abort/compare/v0.2.1...HEAD
+[v0.2.1]: https://github.com/japaric/panic-abort/compare/v0.2.0...v0.2.1
 [v0.2.0]: https://github.com/japaric/panic-abort/compare/v0.1.1...v0.2.0
 [v0.1.1]: https://github.com/japaric/panic-abort/compare/v0.1.0...v0.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-## [v0.2.1] - 2018-09-03
+## [v0.3.0] - 2018-09-03
 
-- Move from the `panic_implementation` attribute to the `panic_handler`
-  attribute, which will be stabilized.
+- [breaking-change] Move from the `panic_implementation` attribute to the
+  `panic_handler` attribute, which will be stabilized.
 
 ## [v0.2.0] - 2018-06-04
 
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Initial release
 
-[Unreleased]: https://github.com/japaric/panic-abort/compare/v0.2.1...HEAD
-[v0.2.1]: https://github.com/japaric/panic-abort/compare/v0.2.0...v0.2.1
+[Unreleased]: https://github.com/japaric/panic-abort/compare/v0.3.0...HEAD
+[v0.3.0]: https://github.com/japaric/panic-abort/compare/v0.2.0...v0.3.0
 [v0.2.0]: https://github.com/japaric/panic-abort/compare/v0.1.1...v0.2.0
 [v0.1.1]: https://github.com/japaric/panic-abort/compare/v0.1.0...v0.1.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,4 @@ keywords = ["panic-impl", "panic", "abort"]
 license = "MIT OR Apache-2.0"
 name = "panic-abort"
 repository = "https://github.com/japaric/panic-abort"
-version = "0.2.0"
+version = "0.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,4 @@ keywords = ["panic-impl", "panic", "abort"]
 license = "MIT OR Apache-2.0"
 name = "panic-abort"
 repository = "https://github.com/japaric/panic-abort"
-version = "0.2.1"
+version = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["Jorge Aparicio <jorge@japaric.io>"]
 categories = ["no-std"]
 description = "Set panicking behavior to abort"
+documentation = "https://japaric.github.io/panic-abort/panic_abort"
 keywords = ["panic-impl", "panic", "abort"]
 license = "MIT OR Apache-2.0"
 name = "panic-abort"

--- a/ci/after-success.sh
+++ b/ci/after-success.sh
@@ -1,0 +1,20 @@
+set -euxo pipefail
+
+main() {
+    cargo doc
+
+    mkdir ghp-import
+
+    curl -Ls https://github.com/davisp/ghp-import/archive/master.tar.gz |
+        tar --strip-components 1 -C ghp-import -xz
+
+    ./ghp-import/ghp_import.py target/doc
+
+    set +x
+    git push -fq https://$GH_TOKEN@github.com/$TRAVIS_REPO_SLUG.git gh-pages && echo OK
+}
+
+# only publish on successful merges to master
+if [ $TRAVIS_BRANCH = master ] && [ $TRAVIS_PULL_REQUEST = false ] && [ $TARGET = x86_64-unknown-linux-gnu ]; then
+    main
+fi

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,13 +19,13 @@
 #![deny(missing_docs)]
 #![deny(warnings)]
 #![feature(core_intrinsics)]
-#![feature(panic_implementation)]
+#![feature(panic_handler)]
 #![no_std]
 
 use core::intrinsics;
 use core::panic::PanicInfo;
 
-#[panic_implementation]
+#[panic_handler]
 fn panic(_info: &PanicInfo) -> ! {
     unsafe { intrinsics::abort() }
 }


### PR DESCRIPTION
the later has been deprecated

This just landed on nightly so let's wait a week or so before merging this to
avoid breaking users that don't update their nightlies so often